### PR TITLE
Don't specify the bugfix version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ readme = "README.md"
 exclude = [".gitignore", ".vscode/*", ".github/*"]
 
 [dependencies]
-criterion = "0.3.4"
-perfcnt = "0.6.0"
+criterion = "0.3"
+perfcnt = "0.6"


### PR DESCRIPTION
Specify the bugfix version is not a good idea, as it will force the users of this library to upgrade or downgrade their dependencies :imp: