### PR TITLE
Update perfcnt to 0.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [".gitignore", ".vscode/*", ".github/*"]
 
 [dependencies]
 criterion = "0.3.4"
-perfcnt = "0.7.0"
+perfcnt = "0.7.2"
 
 [[bench]]
 path = "examples/fibo_bench.rs"


### PR DESCRIPTION
As explained in https://github.com/gz/rust-perfcnt/pull/23, currently this crate is broken on the latest Rust nightly builds due to a transitive dependency on an old version of the x86 crate.

Fix the situation by updating the direct dependency that pulled an older transitive dependency, as its latest version is now fixed.