### PR TITLE
Update criterion to 0.5.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.59.0  # MSRV
+          - 1.64.0  # MSRV
 
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 exclude = [".gitignore", ".vscode/*", ".github/*"]
 
 [dependencies]
-criterion = "0.4.0"
+criterion = "0.5.0"
 perfcnt = "0.8.0"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Measure perf events for criterion"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jbreitbart/criterion-perf-events"
 readme = "README.md"
+rust-version = "1.64"
 
 exclude = [".gitignore", ".vscode/*", ".github/*"]
 


### PR DESCRIPTION
Updating the dependency on Criterion allows downstream projects to also update theirs, as otherwise a conflicting version of Criterion's traits will be implemented, causing build errors.